### PR TITLE
refactor(string-matching): convert unused capture group to non-capture

### DIFF
--- a/string-matching/contestants/regex.js
+++ b/string-matching/contestants/regex.js
@@ -7,7 +7,7 @@ const {
 } = require("./common");
 
 function testString(val) {
-  return /^application\/([a-z.-]+\+)?json/.test(val);
+  return /^application\/(?:[.a-z-]+\+)?json/.test(val);
 }
 
 function execute() {


### PR DESCRIPTION
Changed capture group `(...)` to non-capture group `(?:...)` as nothing is done with the captured text in this test; the regex engine is doing extra work capturing text only to end up not using it.