### PR TITLE
add string-based benchmarks

### DIFF
--- a/cache-get-inmemory-string/contestants/async-cache-dedupe.js
+++ b/cache-get-inmemory-string/contestants/async-cache-dedupe.js
@@ -1,0 +1,33 @@
+const { MAX_ITEMS, TTL, ELEMENT_COUNT } = require("./common");
+const { createCache } = require("async-cache-dedupe");
+
+const cache = createCache({
+  ttl: Math.round(TTL / 1000), // seconds
+  storage: { type: "memory", options: { size: MAX_ITEMS } },
+  transformer: {
+    serialize: (result) => result,
+    deserialize: (serialized) => serialized,
+  }
+});
+
+cache.define("fetchSomething", (k) => {
+  return Promise.resolve({
+    id: k
+  });
+});
+
+async function execute() {
+  for (var x = 0; x < ELEMENT_COUNT; x++) {
+    await cache.fetchSomething(`id: ${x}`);
+  }
+}
+
+function get(key) {
+  return cache.fetchSomething(key.toString());
+}
+
+module.exports = {
+  get,
+  execute
+};
+

--- a/cache-get-inmemory-string/contestants/common.js
+++ b/cache-get-inmemory-string/contestants/common.js
@@ -1,0 +1,17 @@
+const { validateEqual } = require("validation-utils");
+
+const MAX_ITEMS = 5000
+const TTL = 1000 * 60 * 60
+const ELEMENT_COUNT = 8500
+
+async function validateAccuracy(getFn) {
+  const value = await getFn('123')
+  validateEqual(value.id, '123')
+}
+
+module.exports = {
+  ELEMENT_COUNT,
+  MAX_ITEMS,
+  TTL,
+  validateAccuracy,
+};

--- a/cache-get-inmemory-string/contestants/dataloader.js
+++ b/cache-get-inmemory-string/contestants/dataloader.js
@@ -1,0 +1,25 @@
+const { MAX_ITEMS, TTL, ELEMENT_COUNT } = require("./common");
+const DataLoader = require("dataloader");
+
+const loader = new DataLoader(
+  (keys) => {
+  return Promise.resolve([{
+    id: keys[0]
+  }]);
+});
+
+async function execute() {
+  for (var x = 0; x < ELEMENT_COUNT; x++) {
+    await loader.load(`id: ${x}`);
+  }
+}
+
+function get(key) {
+  return loader.load(key.toString());
+}
+
+module.exports = {
+  get,
+  execute
+};
+

--- a/cache-get-inmemory-string/contestants/layered-loader-fifo-map.js
+++ b/cache-get-inmemory-string/contestants/layered-loader-fifo-map.js
@@ -1,0 +1,33 @@
+const { MAX_ITEMS, TTL, ELEMENT_COUNT } = require("./common");
+const { LoadingOperation } = require('layered-loader')
+
+const loadingOperation = new LoadingOperation({
+  inMemoryCache: {
+    cacheType: 'fifo-map',
+    maxItems: MAX_ITEMS,
+    ttlInMsecs: TTL,
+  },
+  loaders: [{
+    get(key) {
+      return Promise.resolve({
+        id: key
+      })
+    }
+  }]
+})
+
+async function execute() {
+  for (var x = 0; x < ELEMENT_COUNT; x++) {
+    loadingOperation.getInMemoryOnly(`id: ${x}`) || await loadingOperation.getAsyncOnly(`id: ${x}`);
+  }
+}
+
+async function get(key) {
+  return loadingOperation.getInMemoryOnly(key.toString()) || await loadingOperation.getAsyncOnly(key.toString());
+}
+
+module.exports = {
+  get,
+  execute,
+};
+

--- a/cache-get-inmemory-string/contestants/layered-loader-fifo-object.js
+++ b/cache-get-inmemory-string/contestants/layered-loader-fifo-object.js
@@ -1,0 +1,33 @@
+const { MAX_ITEMS, TTL, ELEMENT_COUNT } = require("./common");
+const { LoadingOperation } = require('layered-loader')
+
+const loadingOperation = new LoadingOperation({
+  inMemoryCache: {
+    cacheType: 'fifo-object',
+    maxItems: MAX_ITEMS,
+    ttlInMsecs: TTL,
+  },
+  loaders: [{
+    get(key) {
+      return Promise.resolve({
+        id: key
+      })
+    }
+  }]
+})
+
+async function execute() {
+  for (var x = 0; x < ELEMENT_COUNT; x++) {
+    loadingOperation.getInMemoryOnly(`id: ${x}`) || await loadingOperation.getAsyncOnly(`id: ${x}`);
+  }
+}
+
+async function get(key) {
+  return loadingOperation.getInMemoryOnly(key.toString()) || await loadingOperation.getAsyncOnly(key.toString());
+}
+
+module.exports = {
+  get,
+  execute,
+};
+

--- a/cache-get-inmemory-string/contestants/layered-loader-lru-map.js
+++ b/cache-get-inmemory-string/contestants/layered-loader-lru-map.js
@@ -1,0 +1,33 @@
+const { MAX_ITEMS, TTL, ELEMENT_COUNT } = require("./common");
+const { LoadingOperation } = require('layered-loader')
+
+const loadingOperation = new LoadingOperation({
+  inMemoryCache: {
+    cacheType: 'lru-map',
+    maxItems: MAX_ITEMS,
+    ttlInMsecs: TTL,
+  },
+  loaders: [{
+    get(key) {
+      return Promise.resolve({
+        id: key
+      })
+    }
+  }]
+})
+
+async function execute() {
+  for (var x = 0; x < ELEMENT_COUNT; x++) {
+    loadingOperation.getInMemoryOnly(`id: ${x}`) || await loadingOperation.getAsyncOnly(`id: ${x}`);
+  }
+}
+
+async function get(key) {
+  return loadingOperation.getInMemoryOnly(key.toString()) || await loadingOperation.getAsyncOnly(key.toString());
+}
+
+module.exports = {
+  get,
+  execute,
+};
+

--- a/cache-get-inmemory-string/contestants/layered-loader-lru-object.js
+++ b/cache-get-inmemory-string/contestants/layered-loader-lru-object.js
@@ -1,0 +1,33 @@
+const { MAX_ITEMS, TTL, ELEMENT_COUNT } = require("./common");
+const { LoadingOperation } = require('layered-loader')
+
+const loadingOperation = new LoadingOperation({
+  inMemoryCache: {
+    cacheType: 'lru-object',
+    maxItems: MAX_ITEMS,
+    ttlInMsecs: TTL,
+  },
+  loaders: [{
+    get(key) {
+      return Promise.resolve({
+        id: key
+      })
+    }
+  }]
+})
+
+async function execute() {
+  for (var x = 0; x < ELEMENT_COUNT; x++) {
+    loadingOperation.getInMemoryOnly(`id: ${x}`) || await loadingOperation.getAsyncOnly(`id: ${x}`);
+  }
+}
+
+async function get(key) {
+  return loadingOperation.getInMemoryOnly(key.toString()) || await loadingOperation.getAsyncOnly(key.toString());
+}
+
+module.exports = {
+  get,
+  execute,
+};
+

--- a/cache-get-inmemory-string/contestants/tiny-lru.js
+++ b/cache-get-inmemory-string/contestants/tiny-lru.js
@@ -1,0 +1,37 @@
+const { MAX_ITEMS, TTL, ELEMENT_COUNT } = require("./common");
+const { lru } = require('tiny-lru')
+
+const cache = lru(MAX_ITEMS, TTL)
+
+async function execute() {
+  for (var x = 0; x < ELEMENT_COUNT; x++) {
+    const value = cache.get(`id: ${x}`)
+    if (!value) {
+      const newValue = {
+        id: x
+      }
+
+      cache.set(`id: ${x}`, newValue)
+    }
+  }
+}
+
+async function get(key) {
+  const value = cache.get(key)
+  if (!value) {
+    const newValue = {
+      id: key
+    }
+
+    cache.set(key, newValue)
+    return newValue
+  }
+
+  return value
+}
+
+module.exports = {
+  get,
+  execute,
+};
+

--- a/cache-get-inmemory-string/contestants/toad-cache-lru-map.js
+++ b/cache-get-inmemory-string/contestants/toad-cache-lru-map.js
@@ -1,0 +1,37 @@
+const { MAX_ITEMS, TTL, ELEMENT_COUNT } = require("./common");
+const { LruMap } = require('toad-cache')
+
+const cache = new LruMap(MAX_ITEMS, TTL)
+
+async function execute() {
+  for (var x = 0; x < ELEMENT_COUNT; x++) {
+    const value = cache.get(`id: ${x}`)
+    if (!value) {
+      const newValue = {
+        id: x
+      }
+
+      cache.set(`id: ${x}`, newValue)
+    }
+  }
+}
+
+async function get(key) {
+  const value = cache.get(key)
+  if (!value) {
+    const newValue = {
+      id: key
+    }
+
+    cache.set(key, newValue)
+    return newValue
+  }
+
+  return value
+}
+
+module.exports = {
+  get,
+  execute,
+};
+

--- a/cache-get-inmemory-string/contestants/toad-cache-lru-object.js
+++ b/cache-get-inmemory-string/contestants/toad-cache-lru-object.js
@@ -1,0 +1,37 @@
+const { MAX_ITEMS, TTL, ELEMENT_COUNT } = require("./common");
+const { LruObject } = require('toad-cache')
+
+const cache = new LruObject(MAX_ITEMS, TTL)
+
+async function execute() {
+  for (var x = 0; x < ELEMENT_COUNT; x++) {
+    const value = cache.get(`id: ${x}`)
+    if (!value) {
+      const newValue = {
+        id: x
+      }
+
+      cache.set(`id: ${x}`, newValue)
+    }
+  }
+}
+
+async function get(key) {
+  const value = cache.get(key)
+  if (!value) {
+    const newValue = {
+      id: key
+    }
+
+    cache.set(key, newValue)
+    return newValue
+  }
+
+  return value
+}
+
+module.exports = {
+  get,
+  execute,
+};
+

--- a/cache-get-inmemory-string/executioner.js
+++ b/cache-get-inmemory-string/executioner.js
@@ -1,0 +1,48 @@
+const { resolveContestant } = require("../common/src/contestantResolver");
+const { getMeasureFn } = require("../common/src/executionUtils");
+
+const { get: layeredLoaderLruGetFn, execute: layeredLoaderLruFn } = require("./contestants/layered-loader-lru-map");
+const { get: layeredLoaderLruObjectGetFn, execute: layeredLoaderLruObjectFn } = require("./contestants/layered-loader-lru-object");
+const { get: layeredLoaderFifoGetFn, execute: layeredLoaderFifoFn } = require("./contestants/layered-loader-fifo-map");
+const { get: layeredLoaderFifoObjectGetFn, execute: layeredLoaderFifoObjectFn } = require("./contestants/layered-loader-fifo-object");
+const { get: dataLoaderGetFn, execute: dataLoaderFn } = require("./contestants/dataloader");
+const { get: toadCacheLruGetFn, execute: toadCacheLruFn } = require("./contestants/toad-cache-lru-object");
+const { get: toadCacheLruMapGetFn, execute: toadCacheLruMapFn } = require("./contestants/toad-cache-lru-map");
+const { get: tinyLruGetFn, execute: tinyLruFn } = require("./contestants/tiny-lru");
+const {
+  get: asyncCacheDedupeGetFn, execute: asyncCacheDedupeFn,
+} = require("./contestants/async-cache-dedupe");
+
+const { validateAccuracy } = require("./contestants/common");
+
+const benchParams = {
+  warmup: 300,
+  cycles: 500
+}
+
+const contestants = {
+  _layeredLoaderLru: getMeasureFn("layered-loader-lru-map", layeredLoaderLruFn, benchParams),
+  _layeredLoaderLruObject: getMeasureFn("layered-loader-lru-object", layeredLoaderLruObjectFn, benchParams),
+  _layeredLoaderFifo: getMeasureFn("layered-loader-fifo-map", layeredLoaderFifoFn, benchParams),
+  _layeredLoaderFifoObject: getMeasureFn("layered-loader-fifo-object", layeredLoaderFifoObjectFn, benchParams),
+  _dataLoader: getMeasureFn("dataloader", dataLoaderFn, benchParams),
+  _asyncCacheDedupe: getMeasureFn("async-cache-dedupe", asyncCacheDedupeFn, benchParams),
+  _toadCacheLru: getMeasureFn("toad-cache-lru", toadCacheLruFn, benchParams),
+  _toadCacheLruMap: getMeasureFn("toad-cache-lru-map", toadCacheLruMapFn, benchParams),
+  _tinyLru: getMeasureFn("tiny-lru", tinyLruFn, benchParams),
+};
+
+Promise.all([
+  validateAccuracy(layeredLoaderLruGetFn),
+  validateAccuracy(layeredLoaderLruObjectGetFn),
+  validateAccuracy(layeredLoaderFifoGetFn),
+  validateAccuracy(layeredLoaderFifoObjectGetFn),
+  validateAccuracy(dataLoaderGetFn),
+  validateAccuracy(asyncCacheDedupeGetFn),
+  validateAccuracy(toadCacheLruGetFn),
+  validateAccuracy(toadCacheLruMapGetFn),
+  validateAccuracy(tinyLruGetFn),
+]).then(() => {
+  const contestant = resolveContestant(contestants);
+  contestant();
+});

--- a/cache-get-inmemory-string/package-lock.json
+++ b/cache-get-inmemory-string/package-lock.json
@@ -1,0 +1,476 @@
+{
+  "name": "cache",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cache",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "async-cache-dedupe": "1.10.2",
+        "dataloader": "2.2.2",
+        "getopts": "^2.3.0",
+        "layered-loader": "10.0.0",
+        "photofinish": "^1.8.0",
+        "tiny-lru": "11.0.0",
+        "toad-cache": "3.0.1",
+        "validation-utils": "^7.0.0"
+      },
+      "devDependencies": {
+        "prettier": "^2.2.1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async-cache-dedupe": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/async-cache-dedupe/-/async-cache-dedupe-1.10.2.tgz",
+      "integrity": "sha512-sfZaST9/R5xfWi+CHAyftZ4B27/j45pU0yI/D/l0OdZMhPbWutGiFppmPj/AsvO1yrxOVsrjTIOCdCE3hUdBWA==",
+      "dependencies": {
+        "mnemonist": "^0.39.2",
+        "safe-stable-stringify": "^2.3.1"
+      }
+    },
+    "node_modules/dataloader": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.2.tgz",
+      "integrity": "sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g=="
+    },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/getopts": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.3.0.tgz",
+      "integrity": "sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA=="
+    },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isnumber": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isnumber/-/isnumber-1.0.0.tgz",
+      "integrity": "sha512-JLiSz/zsZcGFXPrB4I/AGBvtStkt+8QmksyZBZnVXnnK9XdTEyz0tX8CRYljtwYDuIuZzih6DpHQdi+3Q6zHPw=="
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/layered-loader": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/layered-loader/-/layered-loader-10.0.0.tgz",
+      "integrity": "sha512-Pe6N9jwf1aSPeukwMokit7Kil5Vkg8Wyx8K6zzFT59hxvTPkevJTHRYLa46ZrP/FSkBetnqd+TOk+aSn7olmiQ==",
+      "dependencies": {
+        "toad-cache": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/load-goblin": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/load-goblin/-/load-goblin-1.0.2.tgz",
+      "integrity": "sha512-6XZNI9cnZiRnhdXsNeLA2hEx85gyTKBUMy8hdp2wXA+7oPWPpLqWrTrVCpWs+JXEnSIBH0/WdH5RO4zQDbt1Ug==",
+      "dependencies": {
+        "js-yaml": "^3.14.1",
+        "matcher": "^3.0.0"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+      "dependencies": {
+        "repeat-string": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mnemonist": {
+      "version": "0.39.5",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.5.tgz",
+      "integrity": "sha512-FPUtkhtJ0efmEFGpU14x7jGbTB+s18LrzRL2KgoWz9YvcY3cPomz8tih01GbHwnGk/OmkOKfqd/RAQoc8Lm7DQ==",
+      "dependencies": {
+        "obliterator": "^2.0.1"
+      }
+    },
+    "node_modules/obliterator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
+      "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ=="
+    },
+    "node_modules/percentile": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/percentile/-/percentile-1.6.0.tgz",
+      "integrity": "sha512-8vSyjdzwxGDHHwH+cSGch3A9Uj2On3UpgOWxWXMKwUvoAbnujx6DaqmV1duWXNiH/oEWpyVd6nSQccix6DM3Ng=="
+    },
+    "node_modules/photofinish": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/photofinish/-/photofinish-1.8.0.tgz",
+      "integrity": "sha512-yYv1Kk9NtkkCm9pKNWSX0BlPWh01S4xowTZS/PYNdJH69tV3A3Jua9IRNUNr5pRxgY7a+5uY7081yMos8OdDig==",
+      "dependencies": {
+        "load-goblin": "^1.0.2",
+        "markdown-table": "^2.0.0",
+        "percentile": "^1.4.0",
+        "sort-on": "^4.1.0",
+        "stats-lite": "^2.2.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sort-on": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/sort-on/-/sort-on-4.1.1.tgz",
+      "integrity": "sha512-nj8myvTCEErLMMWnye61z1pV5osa7njoosoQNdylD8WyPYHoHCBQx/xn7mGJL6h4oThvGpYSIAxfm8VUr75qTQ==",
+      "dependencies": {
+        "arrify": "^2.0.1",
+        "dot-prop": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
+    "node_modules/stats-lite": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stats-lite/-/stats-lite-2.2.0.tgz",
+      "integrity": "sha512-/Kz55rgUIv2KP2MKphwYT/NCuSfAlbbMRv2ZWw7wyXayu230zdtzhxxuXXcvsc6EmmhS8bSJl3uS1wmMHFumbA==",
+      "dependencies": {
+        "isnumber": "~1.0.0"
+      },
+      "engines": {
+        "node": ">=2.0.0"
+      }
+    },
+    "node_modules/tiny-lru": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.0.0.tgz",
+      "integrity": "sha512-mtK699zc38JhVKqJlSaQOI8i/LjZ4ZLHHXLQIRXRFtSQOYEH6iYrzqIbGxDrTSkiJqe/lQHrlAGweZjX2jbfpQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/toad-cache": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.0.1.tgz",
+      "integrity": "sha512-+ZAIbg9DzUSXJHnUHf1zqKkgicUFGTgCEuuut8w1Yy+0oJQQngncAFo5UKbHiPahx04oxuo28N9pDTJN2t+fLg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/validation-utils": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/validation-utils/-/validation-utils-7.0.0.tgz",
+      "integrity": "sha512-r8lpeXT3FcSX2yqzoojcEUMZ2HUFNvs0zNHHKKOHTzZzqdB3OFSLCSOsOL8GyDu301llfw/fY7f3r8LScZNclg==",
+      "dependencies": {
+        "zoology": "^1.0.0"
+      }
+    },
+    "node_modules/zoology": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/zoology/-/zoology-1.0.0.tgz",
+      "integrity": "sha512-f6rS5IpDQ/oh9EfDGZx15TINJwyQAn4/db71kOROOzM5kV2aGcBRCjaLiLpgzdAiwl2xhXo04faDzM0BY6Xn0Q=="
+    }
+  },
+  "dependencies": {
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+    },
+    "async-cache-dedupe": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/async-cache-dedupe/-/async-cache-dedupe-1.10.2.tgz",
+      "integrity": "sha512-sfZaST9/R5xfWi+CHAyftZ4B27/j45pU0yI/D/l0OdZMhPbWutGiFppmPj/AsvO1yrxOVsrjTIOCdCE3hUdBWA==",
+      "requires": {
+        "mnemonist": "^0.39.2",
+        "safe-stable-stringify": "^2.3.1"
+      }
+    },
+    "dataloader": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.2.tgz",
+      "integrity": "sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g=="
+    },
+    "dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "requires": {
+        "is-obj": "^2.0.0"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "getopts": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.3.0.tgz",
+      "integrity": "sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA=="
+    },
+    "is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
+    },
+    "isnumber": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isnumber/-/isnumber-1.0.0.tgz",
+      "integrity": "sha512-JLiSz/zsZcGFXPrB4I/AGBvtStkt+8QmksyZBZnVXnnK9XdTEyz0tX8CRYljtwYDuIuZzih6DpHQdi+3Q6zHPw=="
+    },
+    "js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "layered-loader": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/layered-loader/-/layered-loader-10.0.0.tgz",
+      "integrity": "sha512-Pe6N9jwf1aSPeukwMokit7Kil5Vkg8Wyx8K6zzFT59hxvTPkevJTHRYLa46ZrP/FSkBetnqd+TOk+aSn7olmiQ==",
+      "requires": {
+        "toad-cache": "^3.0.0"
+      }
+    },
+    "load-goblin": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/load-goblin/-/load-goblin-1.0.2.tgz",
+      "integrity": "sha512-6XZNI9cnZiRnhdXsNeLA2hEx85gyTKBUMy8hdp2wXA+7oPWPpLqWrTrVCpWs+JXEnSIBH0/WdH5RO4zQDbt1Ug==",
+      "requires": {
+        "js-yaml": "^3.14.1",
+        "matcher": "^3.0.0"
+      }
+    },
+    "markdown-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+      "requires": {
+        "repeat-string": "^1.0.0"
+      }
+    },
+    "matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "requires": {
+        "escape-string-regexp": "^4.0.0"
+      }
+    },
+    "mnemonist": {
+      "version": "0.39.5",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.5.tgz",
+      "integrity": "sha512-FPUtkhtJ0efmEFGpU14x7jGbTB+s18LrzRL2KgoWz9YvcY3cPomz8tih01GbHwnGk/OmkOKfqd/RAQoc8Lm7DQ==",
+      "requires": {
+        "obliterator": "^2.0.1"
+      }
+    },
+    "obliterator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
+      "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ=="
+    },
+    "percentile": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/percentile/-/percentile-1.6.0.tgz",
+      "integrity": "sha512-8vSyjdzwxGDHHwH+cSGch3A9Uj2On3UpgOWxWXMKwUvoAbnujx6DaqmV1duWXNiH/oEWpyVd6nSQccix6DM3Ng=="
+    },
+    "photofinish": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/photofinish/-/photofinish-1.8.0.tgz",
+      "integrity": "sha512-yYv1Kk9NtkkCm9pKNWSX0BlPWh01S4xowTZS/PYNdJH69tV3A3Jua9IRNUNr5pRxgY7a+5uY7081yMos8OdDig==",
+      "requires": {
+        "load-goblin": "^1.0.2",
+        "markdown-table": "^2.0.0",
+        "percentile": "^1.4.0",
+        "sort-on": "^4.1.0",
+        "stats-lite": "^2.2.0"
+      }
+    },
+    "prettier": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="
+    },
+    "safe-stable-stringify": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g=="
+    },
+    "sort-on": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/sort-on/-/sort-on-4.1.1.tgz",
+      "integrity": "sha512-nj8myvTCEErLMMWnye61z1pV5osa7njoosoQNdylD8WyPYHoHCBQx/xn7mGJL6h4oThvGpYSIAxfm8VUr75qTQ==",
+      "requires": {
+        "arrify": "^2.0.1",
+        "dot-prop": "^5.0.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
+    "stats-lite": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stats-lite/-/stats-lite-2.2.0.tgz",
+      "integrity": "sha512-/Kz55rgUIv2KP2MKphwYT/NCuSfAlbbMRv2ZWw7wyXayu230zdtzhxxuXXcvsc6EmmhS8bSJl3uS1wmMHFumbA==",
+      "requires": {
+        "isnumber": "~1.0.0"
+      }
+    },
+    "tiny-lru": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.0.0.tgz",
+      "integrity": "sha512-mtK699zc38JhVKqJlSaQOI8i/LjZ4ZLHHXLQIRXRFtSQOYEH6iYrzqIbGxDrTSkiJqe/lQHrlAGweZjX2jbfpQ=="
+    },
+    "toad-cache": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.0.1.tgz",
+      "integrity": "sha512-+ZAIbg9DzUSXJHnUHf1zqKkgicUFGTgCEuuut8w1Yy+0oJQQngncAFo5UKbHiPahx04oxuo28N9pDTJN2t+fLg=="
+    },
+    "validation-utils": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/validation-utils/-/validation-utils-7.0.0.tgz",
+      "integrity": "sha512-r8lpeXT3FcSX2yqzoojcEUMZ2HUFNvs0zNHHKKOHTzZzqdB3OFSLCSOsOL8GyDu301llfw/fY7f3r8LScZNclg==",
+      "requires": {
+        "zoology": "^1.0.0"
+      }
+    },
+    "zoology": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/zoology/-/zoology-1.0.0.tgz",
+      "integrity": "sha512-f6rS5IpDQ/oh9EfDGZx15TINJwyQAn4/db71kOROOzM5kV2aGcBRCjaLiLpgzdAiwl2xhXo04faDzM0BY6Xn0Q=="
+    }
+  }
+}

--- a/cache-get-inmemory-string/package.json
+++ b/cache-get-inmemory-string/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "cache",
+  "version": "1.0.0",
+  "license": "MIT",
+  "dependencies": {
+    "async-cache-dedupe": "1.10.2",
+    "dataloader": "2.2.2",
+    "getopts": "^2.3.0",
+    "layered-loader": "10.0.0",
+    "toad-cache": "3.0.1",
+    "tiny-lru": "11.0.0",
+    "photofinish": "^1.8.0",
+    "validation-utils": "^7.0.0"
+  },
+  "devDependencies": {
+    "prettier": "^2.2.1"
+  },
+  "scripts": {
+    "install-node": "nvm install 20.8.0 && nvm install 18.18.0 && nvm install 16.20.2",
+    "benchmark:layered-loader-lru": "node executioner.js -c _layeredLoaderLru",
+    "benchmark:layered-loader-lru-object": "node executioner.js -c _layeredLoaderLruObject",
+    "benchmark:layered-loader-fifo": "node executioner.js -c _layeredLoaderFifo",
+    "benchmark:layered-loader-fifo-object": "node executioner.js -c _layeredLoaderFifoObject",
+    "benchmark:toad-cache": "node executioner.js -c _toadCacheLru",
+    "benchmark:toad-cache-map": "node executioner.js -c _toadCacheLruMap",
+    "benchmark:tiny-lru": "node executioner.js -c _tinyLru",
+    "benchmark:data-loader": "node executioner.js -c _dataLoader",
+    "benchmark:async-cache-dedupe": "node executioner.js -c _asyncCacheDedupe",
+    "benchmark-layered-loader": "npm run benchmark:layered-loader-lru && npm run benchmark:layered-loader-fifo && npm run benchmark:layered-loader-lru-object && npm run benchmark:layered-loader-fifo-object",
+    "benchmark-all": "npm run benchmark:async-cache-dedupe && npm run benchmark:data-loader && npm run benchmark:layered-loader-lru && npm run benchmark:layered-loader-fifo && npm run benchmark:layered-loader-lru-object && npm run benchmark:layered-loader-fifo-object && npm run benchmark:toad-cache && npm run benchmark:toad-cache-map && npm run benchmark:tiny-lru",
+    "combine-results": "node ../common/src/resultsCombinator.js -r _results -p 6",
+    "prettier": "prettier --write \\\\\\\"contestants/**/*.{js,ts}\\\\\\\" executioner.js"
+  }
+}

--- a/cache-get-inmemory-string/regenerate-layered-loader.cmd
+++ b/cache-get-inmemory-string/regenerate-layered-loader.cmd
@@ -1,0 +1,14 @@
+rem Make sure to run this in Admin account
+rem
+call npm run install-node
+timeout /t 2
+call nvm use 16.20.2
+timeout /t 2
+call npm run benchmark-layered-loader
+call nvm use 18.18.0
+timeout /t 2
+call npm run benchmark-layered-loader
+call nvm use 20.8.0
+timeout /t 2
+call npm run benchmark-layered-loader
+call npm run combine-results

--- a/cache-get-inmemory-string/regenerate.cmd
+++ b/cache-get-inmemory-string/regenerate.cmd
@@ -1,0 +1,14 @@
+rem Make sure to run this in Admin account
+rem
+call npm run install-node
+timeout /t 2
+call nvm use 16.20.2
+timeout /t 2
+call npm run benchmark-all
+call nvm use 18.18.0
+timeout /t 2
+call npm run benchmark-all
+call nvm use 20.8.0
+timeout /t 2
+call npm run benchmark-all
+call npm run combine-results


### PR DESCRIPTION
Related: https://github.com/kibertoad/toad-cache/issues/40

Results:
```bash
{ cpu: { brand: 'M1', speed: '2.40 GHz' } }
| Node   | Option             | Msecs/op       | Ops/sec | V8                    |
| ------ | ------------------ | -------------- | ------- | --------------------- |
| 20.9.0 | toad-cache-lru-map | 1.352299 msecs | 739.481 | V8 11.3.244.8-node.16 |
| 20.9.0 | toad-cache-lru     | 1.956262 msecs | 511.179 | V8 11.3.244.8-node.16 |
```